### PR TITLE
[bug fix]: envirement dependency of macOS Mojava

### DIFF
--- a/Full Code/requirements.txt
+++ b/Full Code/requirements.txt
@@ -2,19 +2,19 @@
 gevent==1.2.1
 Klein==17.2.0
 boto3==1.4.4
-typing==3.5.3.0
+typing==3.6.6
 future==0.16.0
 six==1.10.0
 jsonschema==2.6.0
 matplotlib==1.5.3
 requests==2.14.2
 tqdm==4.11.2
-numpy==1.13.1
+numpy==1.15.0
 simplejson==3.11.1
 
 ### Sklearn
-spacy==1.8.2
-scikit-learn==0.19.1
+spacy==2.0.18
+scikit-learn==0.20.0
 sklearn-crfsuite==0.3.5
 
 ###rasa_core


### PR DESCRIPTION
My environment ...

```
Macos Mojava Version 10.14.2 (18C54)
Python 3.6.3 :: Anaconda, Inc
```

The issues that i've come across but fixed belows:

```
g++ -bundle -undefined dynamic_lookup -L/usr/local/var/pyenv/versions/anaconda3-5.0.1/lib -arch x86_64 -L/usr/local/var/pyenv/versions/anaconda3-5.0.1/lib -arch x86_64 -arch x86_64 build/temp.macosx-10.7-x86_64-3.6/spacy/parts_of_speech.o -L/usr/local/var/pyenv/versions/anaconda3-5.0.1/lib -o build/lib.macosx-10.7-x86_64-3.6/spacy/parts_of_speech.cpython-36m-darwin.so -Wl,-rpath,@loader_path/../spacy/platform/darwin/lib
  clang: warning: libstdc++ is deprecated; move to libc++ with a minimum deployment target of OS X 10.9 [-Wdeprecated]
  ld: library not found for -lstdc++
  clang: error: linker command failed with exit code 1 (use -v to see invocation)
  error: command 'g++' failed with exit status 1
  
  ----------------------------------------
  Failed building wheel for spacy
```

cause for the spacy==1.8.2 the libstdc++ is deprecated for Mojava, and the spacy==2.0.18 version works well. And the spacy's dependency of typing numpy also change

```
/usr/local/var/pyenv/versions/anaconda3-5.0.1/lib/python3.6/site-packages/sklearn/preprocessing/label.py:151: DeprecationWarning: The truth value of an empty array is ambiguous. Returning False, but in future this will result in an error. Use `array.size > 0` to check that an array is not empty.
```

scikit-learn #9816 also cause running error,  scikit-learn==0.20.0 works well