### PR TITLE
apixu getCurrentWeather function deprecated

### DIFF
--- a/Full Code [Latest release of Rasa NLU and Rasa Core]/actions.py
+++ b/Full Code [Latest release of Rasa NLU and Rasa Core]/actions.py
@@ -15,7 +15,7 @@ class ActionWeather(Action):
 		client = ApixuClient(api_key)
 		
 		loc = tracker.get_slot('location')
-		current = client.getCurrentWeather(q=loc)
+		current = client.current(q=loc)
 		
 		country = current['location']['country']
 		city = current['location']['name']


### PR DESCRIPTION
The latest version of apixu library, contains `current` function in replacement of `getCurrentWeather ` function.