### PR TITLE
changed to client.current

### DIFF
--- a/Full Code [Latest release of Rasa NLU and Rasa Core]/actions.py
+++ b/Full Code [Latest release of Rasa NLU and Rasa Core]/actions.py
@@ -15,7 +15,7 @@ class ActionWeather(Action):
 		client = ApixuClient(api_key)
 		
 		loc = tracker.get_slot('location')
-		current = client.getCurrentWeather(q=loc)
+		current = client.current(q=loc)
 		
 		country = current['location']['country']
 		city = current['location']['name']


### PR DESCRIPTION
due to latest apixu-python release

got error in actions.py when i post location 
AttributeError: 'ApixuClient' object has no attribute 'getCurrentWeather'

changed from client.getCurrentWeather to client.current and it works!!!