### PR TITLE
getcurrent replaced by current

### DIFF
--- a/Full Code [Latest release of Rasa NLU and Rasa Core]/actions.py
+++ b/Full Code [Latest release of Rasa NLU and Rasa Core]/actions.py
@@ -15,7 +15,7 @@ class ActionWeather(Action):
 		client = ApixuClient(api_key)
 		
 		loc = tracker.get_slot('location')
-		current = client.getcurrent(q=loc)
+		current = client.current(q=loc)
 		
 		country = current['location']['country']
 		city = current['location']['name']


### PR DESCRIPTION
`getcurrent` method does not exist anymore. It was replaced by `current` method. 

Line no : 8
`current = client.current(q='London')`
Check this link : https://github.com/apixu/apixu-python/blob/master/examples/current.py