### PR TITLE
API call to Python library for Apixu Weather API incorrect

### DIFF
--- a/Full_Code_Latest/actions.py
+++ b/Full_Code_Latest/actions.py
@@ -15,7 +15,7 @@ class ActionWeather(Action):
 		client = ApixuClient(api_key)
 		
 		loc = tracker.get_slot('location')
-		current = client.getcurrent(q=loc)
+		current = client.current(q=loc)
 		
 		country = current['location']['country']
 		city = current['location']['name']


### PR DESCRIPTION
The [Python library for Apixu Weather API](https://github.com/apixu/apixu-python) object has a method called `current()` instead of `getcurrent()` as you can see in their example [here](https://github.com/apixu/apixu-python/blob/master/examples/current.py)

I figured this out because a community member on the forum ran into issues trying to use your weatherbot_tutorial [here](https://forum.rasa.com/t/custome-action-with-api/13170/7). I also tested it to make sure that it works